### PR TITLE
Setup CI for build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up CMake
+      uses: lukka/get-cmake@v2
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libtbb-dev libboost-all-dev libasound2-dev libdlt-dev libsndfile1-dev
+
+    - name: Create build directory
+      run: mkdir build
+
+    - name: Configure CMake
+      run: cmake -S . -B build
+
+    - name: Build project
+      run: cmake --build build
+
+    - name: Run tests
+      run: ctest --test-dir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,3 +72,9 @@ include( CMakeLists.common.txt )
 #     PACKAGE_BUILD_REQUIRES dlt-daemon
 #   ${ADDITIONAL_RECIPE_CONTENT}
 # )
+
+# Add CI configuration for GitHub Actions
+if (DEFINED ENV{GITHUB_ACTIONS})
+  message(STATUS "Configuring for GitHub Actions CI")
+  include( .github/workflows/ci.yml )
+endif()


### PR DESCRIPTION
Related to #1

Add CI configuration for GitHub Actions to automate the build and test process.

* **CMakeLists.txt**
  - Add a section to include the CI configuration file if running in GitHub Actions environment.

* **.github/workflows/ci.yml**
  - Define a new GitHub Actions workflow for CI.
  - Include steps for setting up dependencies, building, and testing the project.
  - Use `ubuntu-latest` as the build environment.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-AudioModules/issues/1?shareId=2ae13e05-979c-4c9a-8f66-fadc15e9af62).